### PR TITLE
Fix `apply` for Internet Explorer < 9

### DIFF
--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -135,7 +135,7 @@ Backbone.ChildViewContainer = (function(Backbone, _){
       var view;
       _.each(this._views, function(view, key){
         if (_.isFunction(view[method])){
-          view[method].apply(view, args);
+          view[method].apply(view, args || []);
         }
       });
     },


### PR DESCRIPTION
if arguments to `apply` are null or undefined pass an empty array (Internet Explorer < 9 fails otherwise)
