### PR TITLE
Allow chaining of `add` \ `remove` methods

### DIFF
--- a/spec/javascripts/childviewContainer.spec.js
+++ b/spec/javascripts/childviewContainer.spec.js
@@ -121,6 +121,28 @@ describe("childview container", function(){
     });
   });
 
+  describe("adding or removing a view", function(){
+    var container, view, model;
+
+    beforeEach(function(){
+      model = new Backbone.Model();
+
+      view = new Backbone.View({
+        model: model
+      });
+
+      container = new Backbone.ChildViewContainer();
+    });
+
+    it("should return itself when adding, for chaining methods", function(){
+      expect(container.add(view)).toBe(container);
+    });
+
+    it("should return itself when removing, for chaining methods", function(){
+      expect(container.remove(view)).toBe(container);
+    });
+  });
+
   describe("when a container has 2 views in it", function(){
 
     describe("and applying a method with parameters", function(){

--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -44,6 +44,7 @@ Backbone.ChildViewContainer = (function(Backbone, _){
       }
 
       this._updateLength();
+      return this;
     },
 
     // Find a view by the model that was attached to
@@ -99,6 +100,7 @@ Backbone.ChildViewContainer = (function(Backbone, _){
 
       // update the length
       this._updateLength();
+      return this;
     },
 
     // Call a method on every view in the container,


### PR DESCRIPTION
Return `this` when calling `add` \ `remove` for method chaining i.e. `container.add(view1).add(view2).remove(view3)`
