### PR TITLE
Fixed: 0 couldn't be used as index

### DIFF
--- a/spec/javascripts/childviewContainer.spec.js
+++ b/spec/javascripts/childviewContainer.spec.js
@@ -84,6 +84,24 @@ describe("childview container", function(){
     });
   });
 
+  describe("when adding a view with 0 as custom index value", function(){
+    var container, view, foundView;
+
+    beforeEach(function(){
+      view = new Backbone.View();
+
+      container = new Backbone.ChildViewContainer();
+
+      container.add(view, 0);
+
+      foundView = container.findByCustom(0);
+    });
+
+    it("should make the view retrievable by the custom indexer", function(){
+      expect(foundView).toBe(view);
+    });
+  });
+
   describe("when removing a view", function(){
     var container, view, model, col, cust;
 

--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -5,7 +5,7 @@
 // shut down child views.
 
 Backbone.ChildViewContainer = (function(Backbone, _){
-  
+
   // Container Constructor
   // ---------------------
 
@@ -39,7 +39,7 @@ Backbone.ChildViewContainer = (function(Backbone, _){
       }
 
       // index by custom
-      if (customIndex){
+      if (customIndex !== void(0) && customIndex !== null){
         this._indexByCustom[customIndex] = viewCid;
       }
 
@@ -132,9 +132,9 @@ Backbone.ChildViewContainer = (function(Backbone, _){
   //
   // Mix in methods from Underscore, for iteration, and other
   // collection related features.
-  var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter', 
-    'select', 'reject', 'every', 'all', 'some', 'any', 'include', 
-    'contains', 'invoke', 'toArray', 'first', 'initial', 'rest', 
+  var methods = ['forEach', 'each', 'map', 'find', 'detect', 'filter',
+    'select', 'reject', 'every', 'all', 'some', 'any', 'include',
+    'contains', 'invoke', 'toArray', 'first', 'initial', 'rest',
     'last', 'without', 'isEmpty', 'pluck'];
 
   _.each(methods, function(method) {


### PR DESCRIPTION
I have a use case where I want to have the ChildViewContainer ordered. I figured custom indexes were the way to go, but I realized that using value "0" (= first element of the collection) for custom index wasn't working.

This fix should do the trick, tell me if I missed something.

Thanks for the work anyway, it matches my needs almost perfectly.
