### PR TITLE
Clean up dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,8 +44,8 @@
   "github": "https://github.com/marionettejs/backbone.babysitter",
 
   "dependencies": {
-    "jquery": "~1.8.3",
-    "backbone": "~1.0.0"
+    "backbone": ">=0.9.9 <=1.1.2",
+    "underscore": ">=1.4.0 <=1.6.0"
   },
   "devDependencies": {
     "grunt": "~0.4.0",


### PR DESCRIPTION
Similar to [wreqr#19](https://github.com/marionettejs/backbone.wreqr/pull/19), this adds a hard underscore dependency, loosens backbone dependency to prevent multiple `backbone`s being browserified as part of Marionette.js, and removes an unnecessary jquery dependency.

See that pull request for more details.
