### PR TITLE
Remove last occurrences of lib/amd/ directory

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,7 +3,7 @@
   "description": "Manage child views in a Backbone.View",
   "version": "0.1.2",
   "repo": "marionettejs/backbone.babysitter",
-  "main": "lib/amd/backbone.babysitter.js",
+  "main": "lib/backbone.babysitter.js",
   "keywords": [
     "backbone",
     "plugin",

--- a/readme.md
+++ b/readme.md
@@ -20,17 +20,9 @@ list of views.
 Grab the source from the `src` folder above. Grab the most recent builds
 from the links below.
 
-### Standard Builds
-
 * Development: [backbone.babysitter.js](https://raw.github.com/marionettejs/backbone.babysitter/master/lib/backbone.babysitter.js)
 
 * Production: [backbone.babysitter.min.js](https://raw.github.com/marionettejs/backbone.babysitter/master/lib/backbone.babysitter.min.js)
-
-### RequireJS (AMD) Builds
-
-* Development: [backbone.babysitter.js](https://raw.github.com/marionettejs/backbone.babysitter/master/lib/amd/backbone.babysitter.js)
-
-* Production: [backbone.babysitter.min.js](https://raw.github.com/marionettejs/backbone.babysitter/master/lib/amd/backbone.babysitter.min.js)
 
 ## Documentation
 


### PR DESCRIPTION
Having lib/amd in the components dir is also problematic when using
sprockets.
