### PR TITLE
Remove unneeded files from bower package

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,14 @@
     "node_modules",
     "bower_components",
     "test",
-    "tests"
+    "tests",
+    "public",
+    "specs",
+    ".gitignore",
+    ".jshintrc",
+    ".travis.yml",
+    "Gruntfile.js",
+    "component.json",
+    "package.json"
   ]
 }


### PR DESCRIPTION
Files and folders that are useless within the bower package should not be packed.