### PR TITLE
Add a new retrieve method 'findByModelId' #21

### DIFF
--- a/spec/javascripts/childviewContainer.spec.js
+++ b/spec/javascripts/childviewContainer.spec.js
@@ -49,7 +49,7 @@ describe("childview container", function(){
     var container, view, foundView, model;
 
     beforeEach(function(){
-      model = new Backbone.Model();
+      model = new Backbone.Model({'id': 123});
       view = new Backbone.View({
         model: model
       });

--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -36,6 +36,7 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
       // index it by model
       if (view.model){
         this._indexByModel[view.model.cid] = viewCid;
+        if ( view.model.id ) this._indexByModel[view.model.id] = viewCid;
       }
 
       // index by custom
@@ -47,10 +48,10 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
       return this;
     },
 
-    // Find a view by the model that was attached to
-    // it. Uses the model's `cid` to find it.
+    // Find a view by the model that was attached to it.
+    // Uses the model's `id` to find it.
     findByModel: function(model){
-      return this.findByModelCid(model.cid);
+      return this.findByModelCid(model.id);
     },
 
     // Find a view by the `cid` of the model that was attached to

--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -86,6 +86,7 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
       // delete model index
       if (view.model){
         delete this._indexByModel[view.model.cid];
+        delete this._indexByModel[view.model.id];
       }
 
       // delete custom index


### PR DESCRIPTION
Before, `findByModel` and `findByModelCid` do the same thing, now we have 2 indexes by model `id` and `cid`.
`findByModel` to retreive by model `id`, and `findByModelCid`to retreive by model `cid`.
