### PR TITLE
Move add and remove view logic to another function in order to control when to use _updateLength

### DIFF
--- a/spec/javascripts/childviewContainer.spec.js
+++ b/spec/javascripts/childviewContainer.spec.js
@@ -8,7 +8,7 @@ describe("childview container", function(){
         new Backbone.View(),
         new Backbone.View(),
         new Backbone.View()
-      ]
+      ];
       container = new Backbone.ChildViewContainer(views);
     });
 
@@ -85,11 +85,11 @@ describe("childview container", function(){
   });
 
   describe("when removing a view", function(){
-    var container, view, model, col, cust;
+    var container, view, model, cust;
 
     beforeEach(function(){
       model = new Backbone.Model();
-      cust = "custome indexer";
+      cust = "custom indexer";
 
       view = new Backbone.View({
         model: model
@@ -101,9 +101,9 @@ describe("childview container", function(){
       container.remove(view);
     });
 
-    it("should update the size of the chidren", function(){
+    it("should update the size of the children", function(){
       expect(container.length).toBe(0);
-    })
+    });
 
     it("should remove the index by model", function(){
       var v = container.findByModel(model);
@@ -230,7 +230,7 @@ describe("childview container", function(){
       container = new Backbone.ChildViewContainer();
       container.add(view);
 
-      container.each(function(v, k){
+      container.each(function(v){
         views.push(v);
       });
     });

--- a/src/childviewcontainer.js
+++ b/src/childviewcontainer.js
@@ -15,7 +15,7 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
     this._indexByCustom = {};
     this._updateLength();
 
-    _.each(views, this.add, this);
+    _.each(views, _.bind(this.add, this));
   };
 
   // Container Methods
@@ -28,25 +28,9 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
     // cid (and model itself). Optionally specify
     // a custom key to store an retrieve the view.
     add: function(view, customIndex){
-      var viewCid = view.cid;
-
-      // store the view
-      this._views[viewCid] = view;
-
-      // index it by model
-      if (view.model){
-        this._indexByModel[view.model.cid] = viewCid;
-      }
-
-      // index by custom
-      if (customIndex){
-        this._indexByCustom[customIndex] = viewCid;
-      }
-
-      this._updateLength();
-      return this;
+      return this._add(view, customIndex)
+                 ._updateLength();
     },
-
     // Find a view by the model that was attached to
     // it. Uses the model's `cid` to find it.
     findByModel: function(model){
@@ -80,34 +64,15 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
 
     // Remove a view
     remove: function(view){
-      var viewCid = view.cid;
-
-      // delete model index
-      if (view.model){
-        delete this._indexByModel[view.model.cid];
-      }
-
-      // delete custom index
-      _.any(this._indexByCustom, function(cid, key) {
-        if (cid === viewCid) {
-          delete this._indexByCustom[key];
-          return true;
-        }
-      }, this);
-
-      // remove the view from the container
-      delete this._views[viewCid];
-
-      // update the length
-      this._updateLength();
-      return this;
+      return this._remove(view)
+                 ._updateLength();
     },
 
     // Call a method on every view in the container,
     // passing parameters to the call method one at a
     // time, like `function.call`.
     call: function(method){
-      this.apply(method, _.tail(arguments));
+      this.apply(method, _.toArray(arguments).slice(1));
     },
 
     // Apply a method on every view in the container,
@@ -124,6 +89,53 @@ Backbone.ChildViewContainer = (function (Backbone, _) {
     // Update the `.length` attribute on this container
     _updateLength: function(){
       this.length = _.size(this._views);
+
+      return this;
+    },
+    // To be used when avoiding call _updateLength
+    // When you are done adding all your new views
+    // call _updateLength
+    _add: function(view, customIndex){
+      var viewCid = view.cid;
+
+      // store the view
+      this._views[viewCid] = view;
+
+      // index it by model
+      if (view.model){
+        this._indexByModel[view.model.cid] = viewCid;
+      }
+
+      // index by custom
+      if (customIndex){
+        this._indexByCustom[customIndex] = viewCid;
+      }
+
+      return this;
+    },
+    // To be used when avoiding call _updateLength
+    // When you are done adding all your new views
+    // call _updateLength
+    _remove: function (view){
+      var viewCid = view.cid;
+
+      // delete model index
+      if (view.model){
+        delete this._indexByModel[view.model.cid];
+      }
+
+      // delete custom index
+      _.some(this._indexByCustom, _.bind(function(cid, key) {
+        if (cid === viewCid) {
+          delete this._indexByCustom[key];
+          return true;
+        }
+      }, this));
+
+      // remove the view from the container
+      delete this._views[viewCid];
+
+      return this;
     }
   });
 


### PR DESCRIPTION
This will help with marionettejs/backbone.marionette/issues/2873
This change will help when adding a large number of views by using `_add` then later using `_updateLength` after all the views are done getting added. Same use case for `_remove`.

Closes #66 
