### PR TITLE
Move deps to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,11 +37,12 @@
     "url": "https://github.com/marionettejs/backbone.babysitter.git"
   },
   "github": "https://github.com/marionettejs/backbone.babysitter",
-  "dependencies": {
+  "peerDependencies": {
     "backbone": ">=0.9.9 <=1.3.2",
     "underscore": ">=1.4.0 <=1.8.3"
   },
   "devDependencies": {
+    "backbone": ">=0.9.9 <=1.3.2",
     "grunt": "0.4.4",
     "grunt-cli": "0.1.13",
     "grunt-contrib-concat": "0.1.2",
@@ -51,6 +52,7 @@
     "grunt-contrib-uglify": "1.0.1",
     "grunt-contrib-watch": "0.2.0",
     "grunt-preprocess": "4.0.0",
-    "grunt-template": "0.2.3"
+    "grunt-template": "0.2.3",
+    "underscore": ">=1.4.0 <=1.8.3"
   }
 }


### PR DESCRIPTION
To satisfy Mn 3.0's requirement to move deps to peerDeps this should go into an RC to pull into the next Mn 3.0 rc