### PR TITLE
Fix Backbone version range in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "browser"
   ],
   "dependencies": {
-    "backbone": ">=0.9.9 <=1.3.x",
+    "backbone": ">=0.9.9 <1.4",
     "underscore": ">=1.4.0 <=1.8.3"
   },
   "license": "MIT",


### PR DESCRIPTION
Fixes #79 for master, but would still need to be merged into the 1.0.0 branch.